### PR TITLE
Опечатка в описании натива

### DIFF
--- a/scripting/include/aes_v.inc
+++ b/scripting/include/aes_v.inc
@@ -108,7 +108,7 @@ native aes_get_max_level()
 //
 // Returns level name for level num.
 //	
-//	@lvlnum - player id
+//	@level - level number
 //	@level[] - level name output
 //	@len - len
 //	@idLang - language id


### PR DESCRIPTION
Сбил меня с толку, не мог понять почему 
aes_get_level_name(id,level_name, charsmax(level_name))
не работало:D
